### PR TITLE
Fix: resolve AutoMapper version conflict by downgrating to v12.0.1

### DIFF
--- a/HealthConnect.Application/HealthConnect.Application.csproj
+++ b/HealthConnect.Application/HealthConnect.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

This pr is open to fix a conflict that happens with Automapper's version.

# Added 

There were no adding in code because this is a fix pr

# Changes

- Changed the version of the Automapper from 15.0.1 to 12.0.1, resolved problem