### PR TITLE
fix: Add final migration to sync production database

### DIFF
--- a/HealthConnect.Infrastructure/Migrations/20250814223243_FinalizeUserSchema.Designer.cs
+++ b/HealthConnect.Infrastructure/Migrations/20250814223243_FinalizeUserSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HealthConnect.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HealthConnect.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250814223243_FinalizeUserSchema")]
+    partial class FinalizeUserSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HealthConnect.Infrastructure/Migrations/20250814223243_FinalizeUserSchema.cs
+++ b/HealthConnect.Infrastructure/Migrations/20250814223243_FinalizeUserSchema.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HealthConnect.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FinalizeUserSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_CPF",
+                table: "Users",
+                column: "CPF",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_CPF",
+                table: "Users");
+        }
+    }
+}


### PR DESCRIPTION
# Description

## Problem
The previous deployment to Azure failed on startup with a PendingModelChangesWarning. The application's automatic migration process correctly detected that the EF Core model was out of sync with the last applied migration, preventing the app from starting with an inconsistent state.

## Solution
This PR adds the final, consolidated migration file (FinalizeUserSchema) to ensure the database schema is fully synchronized with the current entity model. This will allow the automatic migration process on startup to complete successfully.







