### PR TITLE
fix: put a config to let all urls lowercase, and added a user secrets…

### DIFF
--- a/HealthConnect.Api/DependencyInjection.cs
+++ b/HealthConnect.Api/DependencyInjection.cs
@@ -24,6 +24,15 @@ public static class DependencyInjection
     /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddPresentation(this IServiceCollection services)
     {
+
+        services.AddRouting(options =>
+        {
+            options.LowercaseUrls = true;
+        });
+
+        services.AddControllers()
+            .AddXmlSerializerFormatters();
+
         services.AddControllers();
         services.AddAuthorization();
         services.AddEndpointsApiExplorer();


### PR DESCRIPTION
# Description

This PR is open to fix the error that is ocurring in swagger in all endpoints, added a new configuration in addPresentation to make all urls lowercase to make a pattern, resolved the problem using a user secrets `key`, putting the key inside the `user secrets`